### PR TITLE
Copy the SCRAPfy generated url to the clipbaord

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -3,6 +3,20 @@
 (function() {
 
   /**
+   * Copy the given string to the clipboard
+   */
+  function copyTextToClipboard(text) {
+    var tmpCopyDom = $('<textarea/>');
+    tmpCopyDom.text(text);
+    $('body').append(tmpCopyDom);
+
+    tmpCopyDom.select();
+    document.execCommand('copy', true);
+
+    tmpCopyDom.remove();
+  }
+
+  /**
    * Create a SCRAPfy room with content
    * @param string contentToSend
    */
@@ -17,6 +31,9 @@
         alert('SCRAPfy error: bad response format by the server');
         return false;
       }
+
+      // Copy the link into clipboard
+      copyTextToClipboard(reponseData.url);
 
       // Open the room in new tab
       chrome.tabs.create({

--- a/manifest.json
+++ b/manifest.json
@@ -10,7 +10,8 @@
     "default_popup": "popup.html"
   },
   "permissions": [
-    "tabs"
+    "tabs",
+    "clipboardWrite"
   ],
   "icons": {
     "22": "img/icon.png",


### PR DESCRIPTION
Once "right click + open in SCRAPFy" is run and new tab is opened, copy the generated SCRAPfy url to the clipboard. So it's faster to share the url with co-coders in a second.
